### PR TITLE
Fix email regex escaping in CMS config

### DIFF
--- a/admin/config.yml
+++ b/admin/config.yml
@@ -91,7 +91,7 @@ collections:
         widget: string
         required: false
         pattern:
-          - "^[^\s@]+@[^\s@]+\.[^\s@]+$"
+          - "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$"
           - "Correo inválido"
       - { label: Teléfono, name: telefono, widget: string, required: false }
       - { label: Instagram, name: instagram, widget: string, required: false }
@@ -115,7 +115,7 @@ collections:
         name: email
         widget: string
         pattern:
-          - "^[^\s@]+@[^\s@]+\.[^\s@]+$"
+          - "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$"
           - "Correo inválido"
       - { label: Teléfono, name: telefono, widget: string, required: false }
       - { label: Fecha de nacimiento, name: fecha_nacimiento, widget: datetime, time_format: false, required: false }

--- a/adminp/admin/config.yml
+++ b/adminp/admin/config.yml
@@ -91,7 +91,7 @@ collections:
         widget: string
         required: false
         pattern:
-          - "^[^\s@]+@[^\s@]+\.[^\s@]+$"
+          - "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$"
           - "Correo inválido"
       - { label: Teléfono, name: telefono, widget: string, required: false }
       - { label: Instagram, name: instagram, widget: string, required: false }
@@ -115,7 +115,7 @@ collections:
         name: email
         widget: string
         pattern:
-          - "^[^\s@]+@[^\s@]+\.[^\s@]+$"
+          - "^[^\\s@]+@[^\\s@]+\\.[^\\s@]+$"
           - "Correo inválido"
       - { label: Teléfono, name: telefono, widget: string, required: false }
       - { label: Fecha de nacimiento, name: fecha_nacimiento, widget: datetime, time_format: false, required: false }


### PR DESCRIPTION
## Summary
- escape backslashes in email regex to avoid YAML parsing errors in both CMS config files

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2208cba6483329d0bf7b323651cf3